### PR TITLE
Remove dtl submodule and add it into flake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/dtl"]
-	path = lib/dtl
-	url = https://github.com/cubicdaiya/dtl

--- a/common/diff.cpp
+++ b/common/diff.cpp
@@ -1,5 +1,5 @@
 #include "diff.h"
-#include "../lib/dtl/dtl/dtl.hpp"
+#include <dtl/dtl.hpp>
 
 #include <algorithm>
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,20 @@
       pkgs = import nixpkgs {
         system = "x86_64-linux";
       };
+      dtl = pkgs.stdenv.mkDerivation {
+        name = "dtl";
+        src = pkgs.fetchFromGitHub {
+          repo = "dtl";
+          owner = "cubicdaiya";
+          rev = "32567bb9ec704f09040fb1ed7431a3d967e3df03";
+          sha256 = "1zmjblwya8686h4l5yrf3kbcnfp8laq72ha12gk1nwv149335sxk";
+        };
+
+        installPhase = ''
+          mkdir -p $out/include
+          cp -r $src/dtl $out/include
+        '';
+      };
     in {
       default = pkgs.stdenv.mkDerivation {
         name = "tea";
@@ -24,6 +38,7 @@
           pkgs.protobuf
           pkgs.pkg-config
           pkgs.fuse3
+          dtl
         ];
 
         buildPhase = ''


### PR DESCRIPTION
Related to https://github.com/tea-io/tea/pull/152#discussion_r1876797825.
CI failed for https://github.com/tea-io/tea/pull/152 after changing path to dtl header in include to `<dtl/dtl.hpp>`.
I've fixed it by removing the submodule completely and handling `dtl` library install entirely in `flake.nix`.